### PR TITLE
Fix issues when changing visual studio config.

### DIFF
--- a/PrecompiledHeader.cmake
+++ b/PrecompiledHeader.cmake
@@ -88,8 +88,8 @@ function(add_precompiled_header _target _input)
 
   if(MSVC)
 
-    set(_cxx_path "${CMAKE_CURRENT_BINARY_DIR}/${_target}_cxx_pch")
-    set(_c_path "${CMAKE_CURRENT_BINARY_DIR}/${_target}_c_pch")
+    set(_cxx_path "${CMAKE_CFG_INTDIR}/${_target}_cxx_pch")
+    set(_c_path "${CMAKE_CFG_INTDIR}/${_target}_c_pch")
     make_directory("${_cxx_path}")
     make_directory("${_c_path}")
     set(_pch_cxx_header "${_cxx_path}/${_input}")


### PR DESCRIPTION
Now different .pch files are used for debug/release/etc in visual studio projects.

Before this change switching from debug/release in visual studio would result in lots of pch related errors until you do a rebuild.
